### PR TITLE
XW-1726 | Use mobile view on tablet breakpoint for Global Footer

### DIFF
--- a/base/_breakpoints.scss
+++ b/base/_breakpoints.scss
@@ -12,9 +12,9 @@ $breakpoint-mobile-up: "#{$screen}";
 $breakpoint-mobile-only: "#{$screen} and (max-width:#{$breakpoint-tablet - 1})";
 
 $breakpoint-tablet-up: "#{$screen} and (min-width:#{$breakpoint-tablet})";
+$breakpoint-tablet-down: "#{$screen} and (max-width:#{$breakpoint-desktop - 1})";
 $breakpoint-tablet-only: "#{$screen} and (min-width:#{$breakpoint-tablet}) and (max-width:#{$breakpoint-desktop - 1})";
 
-$breakpoint-desktop-down: "#{$screen} and (max-width:#{$breakpoint-desktop - 1})";
 $breakpoint-desktop-up: "#{$screen} and (min-width:#{$breakpoint-desktop})";
 $breakpoint-desktop-only: "#{$screen} and (min-width:#{$breakpoint-desktop}) and (max-width:#{$breakpoint-desktop-xl - 1})";
 

--- a/base/_breakpoints.scss
+++ b/base/_breakpoints.scss
@@ -14,6 +14,7 @@ $breakpoint-mobile-only: "#{$screen} and (max-width:#{$breakpoint-tablet - 1})";
 $breakpoint-tablet-up: "#{$screen} and (min-width:#{$breakpoint-tablet})";
 $breakpoint-tablet-only: "#{$screen} and (min-width:#{$breakpoint-tablet}) and (max-width:#{$breakpoint-desktop - 1})";
 
+$breakpoint-desktop-down: "#{$screen} and (max-width:#{$breakpoint-desktop - 1})";
 $breakpoint-desktop-up: "#{$screen} and (min-width:#{$breakpoint-desktop})";
 $breakpoint-desktop-only: "#{$screen} and (min-width:#{$breakpoint-desktop}) and (max-width:#{$breakpoint-desktop-xl - 1})";
 

--- a/components/_global-footer.scss
+++ b/components/_global-footer.scss
@@ -302,7 +302,7 @@
 		padding: 0;
 	}
 
-	@media #{$breakpoint-desktop-down} {
+	@media #{$breakpoint-tablet-down} {
 		&__main {
 			margin: 0 20px;
 		}

--- a/components/_global-footer.scss
+++ b/components/_global-footer.scss
@@ -302,7 +302,7 @@
 		padding: 0;
 	}
 
-	@media #{$breakpoint-mobile-only} {
+	@media #{$breakpoint-desktop-down} {
 		&__main {
 			margin: 0 20px;
 		}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-1726
https://github.com/Wikia/design-system-reference-page/pull/42

Add `$breakpoint-desktop-down` and use it in the Global Footer.
Here's the result: http://public.igor.wikia-dev.com/design-system-reference-page/index.html