### PR TITLE
XW-1927 | remove pointer-events:none

### DIFF
--- a/components/_dropdowns.scss
+++ b/components/_dropdowns.scss
@@ -6,9 +6,6 @@ $dropdown-content-z-index: 1;
 	position: relative;
 
 	&__toggle {
-		// In Internet Explorer `:active` pseudo-class is set only on child element,
-		// parent doesn't receive `:active` state.
-		pointer-events: none;
 		position: relative;
 		// dropdown content has shadow that should be hidden below the toggle
 		z-index: $dropdown-content-z-index + 1;


### PR DESCRIPTION
Currently it affects only IE when user started click and didn't mouseup. After mouseup js makes the magic and everything looks ok.

Ping @Wikia/x-wing 