### PR TITLE
XW-2016 | Don't set content-box in DS

### DIFF
--- a/components/_global-navigation.scss
+++ b/components/_global-navigation.scss
@@ -81,7 +81,6 @@ $notification-counter-size: 18px;
 		align-items: center;
 		background-color: $nav-background-color;
 		border-top: $border-top-width solid $color-slate-gray;
-		box-sizing: content-box;
 		color: $color-dark-blue-gray;
 		display: flex;
 		font-size: $typescale-size-minus-1;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "design-system",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Design System developed for Wikia",
   "scripts": {
     "build": "gulp",


### PR DESCRIPTION
This is actually a revert of my last fix for sizes of content boxes in global nav

https://github.com/Wikia/mercury/pull/2777