### PR TITLE
MAIN-12770 | Resolve conflict between app and DS buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+*.iml
 *.DS_Store
 *._.DS_Store
 npm-debug.log

--- a/style-guide/styles/wds-components/_buttons.scss
+++ b/style-guide/styles/wds-components/_buttons.scss
@@ -5,11 +5,14 @@
 	@include button-theming($wds-color-link, $wds-color-white);
 
 	align-items: center;
+	background-image: none;
+	border-radius: 0;
 	border-style: solid;
 	border-width: $wds-button-border-width;
 	box-sizing: content-box;
 	cursor: default;
 	display: inline-flex;
+	font-family: inherit;
 	font-size: $wds-typescale-size-minus-2;
 	font-weight: 600;
 	justify-content: center;
@@ -25,7 +28,6 @@
 	transition-property: background-color, border-color, color;
 	vertical-align: top;
 	-webkit-appearance: none;
-	-webkit-border-radius: 0;
 
 	@at-root button#{&}, a#{&} {
 		cursor: pointer;
@@ -115,5 +117,9 @@
 		&.wds-is-#{$social-name}-color {
 			@include button-theming($social-color, $wds-color-white);
 		}
+	}
+
+	&:hover {
+		background-image: none;
 	}
 }


### PR DESCRIPTION
Currently if WDS styles are used on a `<button>`, `<input type="submit" />` or similar element in app, they conflict with 2010 era Oasis styling. By specifying explicit defaults for some settings we will be able to use these DS styles without having to manually override every single time. This helps avoids issues like https://wikia-inc.atlassian.net/browse/MAIN-12770