### PR TITLE
Link directly to new mediakit url

### DIFF
--- a/app/models/global-footer.json
+++ b/app/models/global-footer.json
@@ -69,10 +69,10 @@
       "header": { "type": "line-text", "title": { "type": "translatable-text", "key": "Advertise" } }, "links": [
         {
           "type": "link-text", "title": { "type": "translatable-text", "key": "Media Kit" },
-          "href": "http:\/\/www.wikia.com\/mediakit"
+          "href": "http:\/\/fandom.wikia.com\/mediakit"
         }, {
           "type": "link-text", "title": { "type": "translatable-text", "key": "Contact" },
-          "href": "http:\/\/www.wikia.com\/mediakit\/contact"
+          "href": "http:\/\/fandom.wikia.com\/mediakit#contact"
         }
       ]
     }, "licensing_and_vertical": {
@@ -218,10 +218,10 @@
       "header": { "type": "line-text", "title": { "type": "translatable-text", "key": "Advertise" } }, "links": [
         {
           "type": "link-text", "title": { "type": "translatable-text", "key": "Media Kit" },
-          "href": "http:\/\/www.wikia.com\/mediakit"
+          "href": "http:\/\/fandom.wikia.com\/mediakit"
         }, {
           "type": "link-text", "title": { "type": "translatable-text", "key": "Contact" },
-          "href": "http:\/\/www.wikia.com\/mediakit\/contact"
+          "href": "http:\/\/fandom.wikia.com\/mediakit#contact"
         }
       ]
     }, "licensing_and_vertical": {


### PR DESCRIPTION
The footer currently links to http://www.wikia.com/mediakit which redirects to fandom.wikia.com/mediakit

Let's take out the middleman and link directly to the page.