### PR TITLE
PLATFORM-3800 | Fix for global nav when there is no community bar

### DIFF
--- a/app/components/wds-global-navigation.js
+++ b/app/components/wds-global-navigation.js
@@ -60,8 +60,12 @@ export default Component.extend({
 	didInsertElement() {
 		this._super(...arguments);
 
-		this.set('communityBarElement', document.querySelector('.wds-community-bar'));
-		window.addEventListener('scroll', this.scrollHandler);
+		const communityBarElement = document.querySelector('.wds-community-bar');
+
+		if (communityBarElement) {
+			this.set('communityBarElement', communityBarElement);
+			window.addEventListener('scroll', this.scrollHandler);
+		}
 	},
 
 	willDestroyElement() {

--- a/app/components/wds-global-navigation.js
+++ b/app/components/wds-global-navigation.js
@@ -77,7 +77,7 @@ export default Component.extend({
 	},
 
 	scrollHandler() {
-		const communityBarOffsetY = this.communityBarElement ? this.communityBarElement.getBoundingClientRect().top : 0;
+		const communityBarOffsetY = this.communityBarElement.getBoundingClientRect().top;
 		const globalNavOffsetY = this.element.getBoundingClientRect().top;
 
 		if (communityBarOffsetY <= globalNavOffsetY && this.communityBarIsActive === false) {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/PLATFORM-3800

We're going to have global navigation without the community bar on the `/language-wikis` path. Before this change we were always getting `true` from `communityBarOffsetY <= globalNavOffsetY` (both equal to `0`) and because of that, global navigation was broken.

@Wikia/core-platform-team @Wikia/iwing 