### PR TITLE
Add generated test files

### DIFF
--- a/app/helpers/wrap-me.js
+++ b/app/helpers/wrap-me.js
@@ -42,9 +42,11 @@ export default helper((params, options) => {
 		className = ` class="${options.className}"`;
 	}
 
-	otherOptionsCombined = Object.keys(otherOptions).map(
-		(key) => (options[key] ? ` ${key}="${options[key]}"` : '')
-	).join('');
+	otherOptionsCombined = Object.keys(otherOptions)
+		.map(key => (options[key] ? ` ${key}="${options[key]}"` : ''))
+		.join('');
 
-	return htmlSafe(`<${tagName}${className}${otherOptionsCombined}>${content}</${tagName}>`).toHTML();
+	return htmlSafe(
+		`<${tagName}${className}${otherOptionsCombined}>${content}</${tagName}>`,
+	).toHTML();
 });

--- a/tests/integration/components/avatar-badge-test.js
+++ b/tests/integration/components/avatar-badge-test.js
@@ -1,0 +1,12 @@
+import { module, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | avatar-badge', function(hooks) {
+	setupRenderingTest(hooks);
+
+	skip('it renders', async function() {
+		await render(hbs`<AvatarBadge />`);
+	});
+});

--- a/tests/integration/components/community-bar/local-navigation-dropdown-test.js
+++ b/tests/integration/components/community-bar/local-navigation-dropdown-test.js
@@ -1,0 +1,12 @@
+import { module, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | community-bar/local-navigation-dropdown', function(hooks) {
+  setupRenderingTest(hooks);
+
+  skip('it renders', async function() {
+    await render(hbs`{{community-bar/local-navigation-dropdown}}`);
+  });
+});

--- a/tests/integration/components/community-bar/local-navigation-dropdown-test.js
+++ b/tests/integration/components/community-bar/local-navigation-dropdown-test.js
@@ -3,10 +3,13 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | community-bar/local-navigation-dropdown', function(hooks) {
-  setupRenderingTest(hooks);
+module(
+	'Integration | Component | community-bar/local-navigation-dropdown',
+	function(hooks) {
+		setupRenderingTest(hooks);
 
-  skip('it renders', async function() {
-    await render(hbs`{{community-bar/local-navigation-dropdown}}`);
-  });
-});
+		skip('it renders', async function() {
+			await render(hbs`{{community-bar/local-navigation-dropdown}}`);
+		});
+	},
+);

--- a/tests/integration/components/community-bar/local-navigation-level-2-test.js
+++ b/tests/integration/components/community-bar/local-navigation-level-2-test.js
@@ -1,0 +1,15 @@
+import { module, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module(
+	'Integration | Component | community-bar/local-navigation-level-2',
+	function(hooks) {
+		setupRenderingTest(hooks);
+
+		skip('it renders', async function() {
+			await render(hbs`{{community-bar/local-navigation-level-2}}`);
+		});
+	},
+);

--- a/tests/integration/components/community-bar/local-navigation-level-3-test.js
+++ b/tests/integration/components/community-bar/local-navigation-level-3-test.js
@@ -1,0 +1,15 @@
+import { module, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module(
+	'Integration | Component | community-bar/local-navigation-level-3',
+	function(hooks) {
+		setupRenderingTest(hooks);
+
+		skip('it renders', async function() {
+			await render(hbs`{{community-bar/local-navigation-level-3}}`);
+		});
+	},
+);

--- a/tests/integration/components/community-bar/local-navigation-test.js
+++ b/tests/integration/components/community-bar/local-navigation-test.js
@@ -1,0 +1,14 @@
+import { module, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | community-bar/local-navigation', function(
+	hooks,
+) {
+	setupRenderingTest(hooks);
+
+	skip('it renders', async function() {
+		await render(hbs`{{community-bar/local-navigation}}`);
+	});
+});

--- a/tests/integration/components/community-header/local-navigation-dropdown-level-2-test.js
+++ b/tests/integration/components/community-header/local-navigation-dropdown-level-2-test.js
@@ -1,0 +1,16 @@
+import { module, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | community-header/local-navigation-dropdown-level-2', function(hooks) {
+  setupRenderingTest(hooks);
+
+  skip('it renders', async function() {
+
+
+
+    await render(hbs`{{community-header/local-navigation-dropdown-level-2}}`);
+
+  });
+});

--- a/tests/integration/components/community-header/local-navigation-dropdown-level-2-test.js
+++ b/tests/integration/components/community-header/local-navigation-dropdown-level-2-test.js
@@ -3,14 +3,15 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | community-header/local-navigation-dropdown-level-2', function(hooks) {
-  setupRenderingTest(hooks);
+module(
+	'Integration | Component | community-header/local-navigation-dropdown-level-2',
+	function(hooks) {
+		setupRenderingTest(hooks);
 
-  skip('it renders', async function() {
-
-
-
-    await render(hbs`{{community-header/local-navigation-dropdown-level-2}}`);
-
-  });
-});
+		skip('it renders', async function() {
+			await render(
+				hbs`{{community-header/local-navigation-dropdown-level-2}}`,
+			);
+		});
+	},
+);

--- a/tests/integration/components/global-navigation/anon-test.js
+++ b/tests/integration/components/global-navigation/anon-test.js
@@ -1,0 +1,12 @@
+import { module, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | global-navigation/anon', function(hooks) {
+	setupRenderingTest(hooks);
+
+	skip('it renders', async function() {
+		await render(hbs`{{global-navigation/anon}}`);
+	});
+});

--- a/tests/integration/components/global-navigation/content-recommendation-card-test.js
+++ b/tests/integration/components/global-navigation/content-recommendation-card-test.js
@@ -1,0 +1,17 @@
+import { module, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module(
+	'Integration | Component | global-navigation/content-recommendation-card',
+	function(hooks) {
+		setupRenderingTest(hooks);
+
+		skip('it renders', async function() {
+			await render(
+				hbs`{{global-navigation/content-recommendation-card}}`,
+			);
+		});
+	},
+);

--- a/tests/integration/components/global-navigation/content-recommendations-test.js
+++ b/tests/integration/components/global-navigation/content-recommendations-test.js
@@ -1,0 +1,15 @@
+import { module, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module(
+	'Integration | Component | global-navigation/content-recommendations',
+	function(hooks) {
+		setupRenderingTest(hooks);
+
+		skip('it renders', async function() {
+			await render(hbs`{{global-navigation/content-recommendations}}`);
+		});
+	},
+);

--- a/tests/integration/components/global-navigation/link-logout-test.js
+++ b/tests/integration/components/global-navigation/link-logout-test.js
@@ -1,0 +1,14 @@
+import { module, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | global-navigation/link-logout', function(
+	hooks,
+) {
+	setupRenderingTest(hooks);
+
+	skip('it renders', async function() {
+		await render(hbs`{{global-navigation/link-logout}}`);
+	});
+});

--- a/tests/integration/components/global-navigation/search-modal-test.js
+++ b/tests/integration/components/global-navigation/search-modal-test.js
@@ -1,0 +1,15 @@
+import { module, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | global-navigation/search-modal', function(
+	hooks,
+) {
+	setupRenderingTest(hooks);
+
+	skip('it renders', async function() {
+		await render(hbs`{{global-navigation/search-modal}}`);
+
+	});
+});

--- a/tests/integration/components/global-navigation/user-modal-test.js
+++ b/tests/integration/components/global-navigation/user-modal-test.js
@@ -1,0 +1,14 @@
+import { module, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | global-navigation/user-modal', function(
+	hooks,
+) {
+	setupRenderingTest(hooks);
+
+	skip('it renders', async function() {
+		await render(hbs`{{global-navigation/user-modal}}`);
+	});
+});

--- a/tests/integration/components/icon-test.js
+++ b/tests/integration/components/icon-test.js
@@ -1,0 +1,12 @@
+import { module, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | icon', function(hooks) {
+	setupRenderingTest(hooks);
+
+	skip('it renders', async function() {
+		await render(hbs`<Icon />`);
+	});
+});

--- a/tests/integration/components/local-navigation-test.js
+++ b/tests/integration/components/local-navigation-test.js
@@ -1,0 +1,12 @@
+import { module, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | local-navigation', function(hooks) {
+	setupRenderingTest(hooks);
+
+	skip('it renders', async function() {
+		await render(hbs`<LocalNavigation />`);
+	});
+});

--- a/tests/integration/components/on-site-notifications/notifications-dropdown-test.js
+++ b/tests/integration/components/on-site-notifications/notifications-dropdown-test.js
@@ -1,0 +1,15 @@
+import { module, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module(
+	'Integration | Component | on-site-notifications/notifications-dropdown',
+	function(hooks) {
+		setupRenderingTest(hooks);
+
+		skip('it renders', async function() {
+			await render(hbs`{{on-site-notifications/notifications-dropdown}}`);
+		});
+	},
+);

--- a/tests/integration/components/on-site-notifications/notifications-test.js
+++ b/tests/integration/components/on-site-notifications/notifications-test.js
@@ -1,0 +1,15 @@
+import { module, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module(
+	'Integration | Component | on-site-notifications/notifications',
+	function(hooks) {
+		setupRenderingTest(hooks);
+
+		skip('it renders', async function() {
+			await render(hbs`{{on-site-notifications/notifications}}`);
+		});
+	},
+);

--- a/tests/integration/components/tab-test.js
+++ b/tests/integration/components/tab-test.js
@@ -1,0 +1,12 @@
+import { module, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | tab', function(hooks) {
+	setupRenderingTest(hooks);
+
+	skip('it renders', async function() {
+		await render(hbs`<Tab />`);
+	});
+});

--- a/tests/integration/components/toggle-test.js
+++ b/tests/integration/components/toggle-test.js
@@ -7,8 +7,8 @@ module('Integration | Component | toggle', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
+
+
 
     await render(hbs`<Toggle @id="my-id"/>`);
 

--- a/tests/integration/helpers/optional-test.js
+++ b/tests/integration/helpers/optional-test.js
@@ -1,0 +1,29 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | optional', function(hooks) {
+	setupRenderingTest(hooks);
+
+	// Replace this with your real tests.
+	test('it renders', async function(assert) {
+		assert.expect(1);
+
+		this.set('onClick', function() {
+			assert.ok(true);
+		});
+
+		await render(
+			hbs`<div class="click-me" {{action (optional onClick)}}></div>`,
+		);
+
+		await click('.click-me');
+
+		await render(
+			hbs`<div class="click-me" {{action (optional empty)}}></div>`,
+		);
+
+		await click('.click-me');
+	});
+});

--- a/tests/integration/helpers/wrap-me-test.js
+++ b/tests/integration/helpers/wrap-me-test.js
@@ -1,0 +1,19 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | wrap-me', function(hooks) {
+	setupRenderingTest(hooks);
+
+	test('it renders', async function(assert) {
+		this.set('testValue', '1234');
+
+		await render(
+			hbs`{{{wrap-me testValue className='test-class'}}}`,
+		);
+
+		assert.dom('span.test-class').exists();
+		assert.dom('.test-class').containsText('1234');
+	});
+});

--- a/tests/integration/helpers/wrap-me-test.js
+++ b/tests/integration/helpers/wrap-me-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import wrapMeHelper from 'discussions/helpers/wrap-me';
+import wrapMeHelper from 'dummy/helpers/wrap-me';
 
 module('Unit | Helper | wrap-me', () => {
 	test('wrap-me helper is exported', assert => {

--- a/tests/integration/helpers/wrap-me-test.js
+++ b/tests/integration/helpers/wrap-me-test.js
@@ -1,19 +1,96 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import wrapMeHelper from 'discussions/helpers/wrap-me';
 
-module('Integration | Helper | wrap-me', function(hooks) {
-	setupRenderingTest(hooks);
+module('Unit | Helper | wrap-me', () => {
+	test('wrap-me helper is exported', assert => {
+		assert.ok(wrapMeHelper.compute);
+	});
 
-	test('it renders', async function(assert) {
-		this.set('testValue', '1234');
+	test('generate default html for passed content', assert => {
+		const options = {};
 
-		await render(
-			hbs`{{{wrap-me testValue className='test-class'}}}`,
+		const html = wrapMeHelper.compute(['some text'], options);
+
+		assert.equal(html, '<span>some text</span>');
+	});
+
+	test('generate html with passed content and one parameter', assert => {
+		const options = {
+			tagName: 'table',
+		};
+
+		const html = wrapMeHelper.compute(['some text'], options);
+
+		assert.equal(html, '<table>some text</table>');
+	});
+
+	test('generate html with passed content and two parameters', assert => {
+		const options = {
+			tagName: 'div',
+			className: 'my-class and another',
+		};
+
+		const html = wrapMeHelper.compute(['some text'], options);
+
+		assert.equal(html, '<div class="my-class and another">some text</div>');
+	});
+
+	test('generate html with passed content and extraneous parameter (ignores the param)', assert => {
+		const options = {
+			notAValidParam: 'nope',
+		};
+
+		const html = wrapMeHelper.compute(['some text'], options);
+
+		assert.equal(html, '<span>some text</span>');
+	});
+
+	test('generate html without any content passed', assert => {
+		const options = {};
+
+		const html = wrapMeHelper.compute([], options);
+
+		assert.equal(html, '<span></span>');
+	});
+
+	test('generate html with unsafe content', assert => {
+		const options = {};
+
+		const html = wrapMeHelper.compute(
+			['some<script>alert(0);</script>text'],
+			options,
 		);
 
-		assert.dom('span.test-class').exists();
-		assert.dom('.test-class').containsText('1234');
+		assert.equal(
+			html,
+			'<span>some&lt;script&gt;alert(0);&lt;/script&gt;text</span>',
+		);
+	});
+
+	test('generate html with a link', assert => {
+		const options = {
+			tagName: 'a',
+			href: '/d/g',
+			className: 'guidelines-opener',
+		};
+
+		const html = wrapMeHelper.compute(['guidelines'], options);
+
+		assert.equal(
+			html,
+			'<a class="guidelines-opener" href="/d/g">guidelines</a>',
+		);
+	});
+
+	test('generate html with a link with a target', assert => {
+		const options = {
+			tagName: 'a',
+			href: '/d/g',
+			target: '_blank',
+		};
+
+		const html = wrapMeHelper.compute(['guidelines'], options);
+
+		assert.equal(html, '<a href="/d/g" target="_blank">guidelines</a>');
 	});
 });

--- a/tests/unit/models/wds-on-site-notifications/wds-on-site-notification-test.js
+++ b/tests/unit/models/wds-on-site-notifications/wds-on-site-notification-test.js
@@ -1,0 +1,13 @@
+import { module, skip } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module(
+	'Unit | Model | wds-on-site-notifications/wds-on-site-notification',
+	function(hooks) {
+		setupTest(hooks);
+
+		skip('it exists', function(assert) {
+			assert.ok();
+		});
+	},
+);

--- a/tests/unit/models/wds-on-site-notifications/wds-on-site-notifications-test.js
+++ b/tests/unit/models/wds-on-site-notifications/wds-on-site-notifications-test.js
@@ -1,0 +1,13 @@
+import { module, skip } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module(
+	'Unit | Service | wds-on-site-notifications/wds-on-site-notifications',
+	function(hooks) {
+		setupTest(hooks);
+
+		skip('it exists', function(assert) {
+			assert.ok();
+		});
+	},
+);

--- a/tests/unit/services/wds-banner-notifications-test.js
+++ b/tests/unit/services/wds-banner-notifications-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | wds-banner-notifications', function(hooks) {
+	setupTest(hooks);
+
+	// Replace this with your real tests.
+	test('it exists', function(assert) {
+		let service = this.owner.lookup('service:wds-banner-notifications');
+		assert.ok(service);
+	});
+});

--- a/tests/unit/services/wds-liftigniter-test.js
+++ b/tests/unit/services/wds-liftigniter-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | wds-liftigniter', function(hooks) {
+	setupTest(hooks);
+
+	test('it exists', function(assert) {
+		let service = this.owner.lookup('service:wds-liftigniter');
+		assert.ok(service);
+	});
+});

--- a/tests/unit/services/wds-on-site-notifications-test.js
+++ b/tests/unit/services/wds-on-site-notifications-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | wds-on-site-notifications', function(hooks) {
+	setupTest(hooks);
+
+	// Replace this with your real tests.
+	test('it exists', function(assert) {
+		let service = this.owner.lookup('service:wds-on-site-notifications');
+		assert.ok(service);
+	});
+});

--- a/tests/unit/utils/local-storage-connector-test.js
+++ b/tests/unit/utils/local-storage-connector-test.js
@@ -1,0 +1,9 @@
+import localStorageConnector from 'dummy/utils/local-storage-connector';
+import { module, skip } from 'qunit';
+
+module('Unit | Utility | local-storage-connector', function() {
+	skip('it works', function(assert) {
+		let result = localStorageConnector();
+		assert.ok(result);
+	});
+});

--- a/tests/unit/utils/local-storage-connector-test.js
+++ b/tests/unit/utils/local-storage-connector-test.js
@@ -1,25 +1,19 @@
-import localStorageConnector from 'dummy/utils/local-storage-connector';
+import localStorageAdapter from 'dummy/utils/local-storage-connector';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | local-storage-connector', function() {
 	test('getItem/setItem works', assert => {
-		const localStorageAdapter = localStorageConnector.localStorageAdapter;
-
 		localStorageAdapter.setItem('foo', 'bar');
 		assert.strictEqual(localStorageAdapter.getItem('foo'), 'bar');
 	});
 
 	test('clear works', assert => {
-		const localStorageAdapter = localStorageConnector.localStorageAdapter;
-
 		localStorageAdapter.setItem('foo', 'bar');
 		localStorageAdapter.removeItem('foo');
 		assert.strictEqual(localStorageAdapter.getItem('foo') || false, false);
 	});
 
 	test('removeItem works', assert => {
-		const localStorageAdapter = localStorageConnector.localStorageAdapter;
-
 		localStorageAdapter.setItem('foo', 'bar');
 		localStorageAdapter.removeItem('foo');
 		assert.strictEqual(localStorageAdapter.getItem('foo') || false, false);

--- a/tests/unit/utils/local-storage-connector-test.js
+++ b/tests/unit/utils/local-storage-connector-test.js
@@ -1,9 +1,27 @@
 import localStorageConnector from 'dummy/utils/local-storage-connector';
-import { module, skip } from 'qunit';
+import { module, test } from 'qunit';
 
 module('Unit | Utility | local-storage-connector', function() {
-	skip('it works', function(assert) {
-		let result = localStorageConnector();
-		assert.ok(result);
+	test('getItem/setItem works', assert => {
+		const localStorageAdapter = localStorageConnector.localStorageAdapter;
+
+		localStorageAdapter.setItem('foo', 'bar');
+		assert.strictEqual(localStorageAdapter.getItem('foo'), 'bar');
+	});
+
+	test('clear works', assert => {
+		const localStorageAdapter = localStorageConnector.localStorageAdapter;
+
+		localStorageAdapter.setItem('foo', 'bar');
+		localStorageAdapter.removeItem('foo');
+		assert.strictEqual(localStorageAdapter.getItem('foo') || false, false);
+	});
+
+	test('removeItem works', assert => {
+		const localStorageAdapter = localStorageConnector.localStorageAdapter;
+
+		localStorageAdapter.setItem('foo', 'bar');
+		localStorageAdapter.removeItem('foo');
+		assert.strictEqual(localStorageAdapter.getItem('foo') || false, false);
 	});
 });

--- a/tests/unit/utils/notification-types-test.js
+++ b/tests/unit/utils/notification-types-test.js
@@ -1,0 +1,9 @@
+import notificationTypes from 'dummy/utils/notification-types';
+import { module, skip } from 'qunit';
+
+module('Unit | Utility | notification-types', function() {
+	skip('it works', function(assert) {
+		let result = notificationTypes();
+		assert.ok(result);
+	});
+});

--- a/tests/unit/utils/thumbnail-test.js
+++ b/tests/unit/utils/thumbnail-test.js
@@ -1,0 +1,9 @@
+import thumbnail from 'dummy/utils/thumbnail';
+import { module, skip } from 'qunit';
+
+module('Unit | Utility | thumbnail', function() {
+	skip('it works', function(assert) {
+		let result = thumbnail();
+		assert.ok(result);
+	});
+});

--- a/tests/unit/utils/wds-track-test.js
+++ b/tests/unit/utils/wds-track-test.js
@@ -1,0 +1,9 @@
+import wdsTrack from 'dummy/utils/wds-track';
+import { module, skip } from 'qunit';
+
+module('Unit | Utility | wds-track', function() {
+	skip('it works', function(assert) {
+		let result = wdsTrack();
+		assert.ok(result);
+	});
+});


### PR DESCRIPTION
I have mostly ran something like this:
`find app/services | grep .js | sed s/app\\/models\\/// | sed s/.js// | xargs -I _ ember generate service-test _`
but for different type of tests

Next step would be to write requirements for each in a form of skipped tests that we'll be able to fill in as we go.