### PR TITLE
IW-1341 | Close navigation when sub-level title is clicked

### DIFF
--- a/app/components/community-bar/local-navigation-dropdown.js
+++ b/app/components/community-bar/local-navigation-dropdown.js
@@ -73,12 +73,7 @@ export default Component.extend({
 		}
 	},
 
-	onThirdLevelSelected(event) {
-		this.toggleNavigation(false);
-		this.onLinkClicked(event);
-	},
-
-	onSubLevelTitleClicked(event) {
+	onNavigationItemLinkClicked(event) {
 		this.toggleNavigation(false);
 		this.onLinkClicked(event);
 	},

--- a/app/components/community-bar/local-navigation-dropdown.js
+++ b/app/components/community-bar/local-navigation-dropdown.js
@@ -78,6 +78,11 @@ export default Component.extend({
 		this.onLinkClicked(event);
 	},
 
+	onSubLevelTitleClicked(event) {
+		this.toggleNavigation(false);
+		this.onLinkClicked(event);
+	},
+
 	resetSelected(propName) {
 		this.set(propName, null);
 	}

--- a/app/templates/components/community-bar/local-navigation-dropdown.hbs
+++ b/app/templates/components/community-bar/local-navigation-dropdown.hbs
@@ -17,6 +17,7 @@
       onThirdLevelSelected=(action onThirdLevelSelected)
       resetSelected=(action resetSelected)
       onLinkClicked=(action onLinkClicked)
+      onSubLevelTitleClicked=(action onSubLevelTitleClicked)
     }}
   </dropdown.content>
 </Dropdown>

--- a/app/templates/components/community-bar/local-navigation-dropdown.hbs
+++ b/app/templates/components/community-bar/local-navigation-dropdown.hbs
@@ -14,10 +14,9 @@
       secondLevelIndexSelected=secondLevelIndexSelected
       onFirstLevelSelected=(action onFirstLevelSelected)
       onSecondLevelSelected=(action onSecondLevelSelected)
-      onThirdLevelSelected=(action onThirdLevelSelected)
+      onNavigationItemLinkClicked=(action onNavigationItemLinkClicked)
       resetSelected=(action resetSelected)
       onLinkClicked=(action onLinkClicked)
-      onSubLevelTitleClicked=(action onSubLevelTitleClicked)
     }}
   </dropdown.content>
 </Dropdown>

--- a/app/templates/components/community-bar/local-navigation-level-2.hbs
+++ b/app/templates/components/community-bar/local-navigation-level-2.hbs
@@ -7,7 +7,7 @@
     class="wds-community-bar__navigation-header"
     href={{firstLevelItem.href}}
     data-tracking-label={{unless (equal firstLevelItem.href "#") firstLevelItem.tracking_label}}
-    onclick={{action onLinkClicked}}
+    onclick={{action onSubLevelTitleClicked}}
   >
     <Label @label={{firstLevelItem.title}} />
   </a>

--- a/app/templates/components/community-bar/local-navigation-level-2.hbs
+++ b/app/templates/components/community-bar/local-navigation-level-2.hbs
@@ -7,7 +7,7 @@
     class="wds-community-bar__navigation-header"
     href={{firstLevelItem.href}}
     data-tracking-label={{unless (equal firstLevelItem.href "#") firstLevelItem.tracking_label}}
-    onclick={{action onSubLevelTitleClicked}}
+    onclick={{action onNavigationItemLinkClicked}}
   >
     <Label @label={{firstLevelItem.title}} />
   </a>

--- a/app/templates/components/community-bar/local-navigation-level-3.hbs
+++ b/app/templates/components/community-bar/local-navigation-level-3.hbs
@@ -9,7 +9,7 @@
     (equal secondLevelItem.href "#")
     secondLevelItem.tracking_label
   }}
-  onclick={{action onSubLevelTitleClicked}}
+  onclick={{action onNavigationItemLinkClicked}}
 >
   <Label @label={{secondLevelItem.title}} />
 </a>
@@ -22,7 +22,7 @@
           (equal thirdLevelItem.href "#")
           thirdLevelItem.tracking_label
         }}
-        onclick={{action onThirdLevelClicked}}
+        onclick={{action onNavigationItemLinkClicked}}
       >
         <Label @label={{thirdLevelItem.title}} />
       </a>

--- a/app/templates/components/community-bar/local-navigation-level-3.hbs
+++ b/app/templates/components/community-bar/local-navigation-level-3.hbs
@@ -9,7 +9,7 @@
     (equal secondLevelItem.href "#")
     secondLevelItem.tracking_label
   }}
-  onclick={{action onLinkClicked}}
+  onclick={{action onSubLevelTitleClicked}}
 >
   <Label @label={{secondLevelItem.title}} />
 </a>

--- a/app/templates/components/community-bar/local-navigation.hbs
+++ b/app/templates/components/community-bar/local-navigation.hbs
@@ -24,6 +24,7 @@
       onSecondLevelClicked=(action onSecondLevelSelected)
       onBackButtonClicked=(action resetSelected "firstLevelIndexSelected")
       onLinkClicked=(action onLinkClicked)
+      onSubLevelTitleClicked=(action onSubLevelTitleClicked)
     }}
     {{#each firstLevelItem.items as |secondLevelItem secondLevelIndex|}}
       {{#if secondLevelItem.items}}
@@ -36,6 +37,7 @@
           onThirdLevelClicked=(action onThirdLevelSelected)
           onBackButtonClicked=(action resetSelected "secondLevelIndexSelected")
           onLinkClicked=(action onLinkClicked)
+          onSubLevelTitleClicked=(action onSubLevelTitleClicked)
         }}
       {{/if}}
     {{/each}}

--- a/app/templates/components/community-bar/local-navigation.hbs
+++ b/app/templates/components/community-bar/local-navigation.hbs
@@ -21,10 +21,10 @@
       firstLevelIndex=firstLevelIndex
       firstLevelIndexSelected=firstLevelIndexSelected
       secondLevelIndexSelected=secondLevelIndexSelected
+      onNavigationItemLinkClicked=(action onNavigationItemLinkClicked)
       onSecondLevelClicked=(action onSecondLevelSelected)
       onBackButtonClicked=(action resetSelected "firstLevelIndexSelected")
       onLinkClicked=(action onLinkClicked)
-      onSubLevelTitleClicked=(action onSubLevelTitleClicked)
     }}
     {{#each firstLevelItem.items as |secondLevelItem secondLevelIndex|}}
       {{#if secondLevelItem.items}}
@@ -34,10 +34,9 @@
           firstLevelIndexSelected=firstLevelIndexSelected
           secondLevelIndex=secondLevelIndex
           secondLevelIndexSelected=secondLevelIndexSelected
-          onThirdLevelClicked=(action onThirdLevelSelected)
+          onNavigationItemLinkClicked=(action onNavigationItemLinkClicked)
           onBackButtonClicked=(action resetSelected "secondLevelIndexSelected")
           onLinkClicked=(action onLinkClicked)
-          onSubLevelTitleClicked=(action onSubLevelTitleClicked)
         }}
       {{/if}}
     {{/each}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1528,7 +1528,7 @@
     },
     "ansi-escapes": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
     },
@@ -1686,7 +1686,7 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
@@ -4869,7 +4869,7 @@
     },
     "content-disposition": {
       "version": "0.5.2",
-      "resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
       "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
       "dev": true
     },
@@ -10299,7 +10299,7 @@
     },
     "external-editor": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
       "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
       "dev": true,
       "requires": {
@@ -12133,7 +12133,7 @@
     },
     "inquirer": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-2.0.0.tgz",
       "integrity": "sha1-4TUWh7kNFQykA86qPO+x4wZb70s=",
       "dev": true,
       "requires": {
@@ -16965,7 +16965,7 @@
     },
     "temp": {
       "version": "0.8.3",
-      "resolved": "http://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
       "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
       "dev": true,
       "requires": {

--- a/tests/integration/components/community-bar/local-navigation-dropdown-test.js
+++ b/tests/integration/components/community-bar/local-navigation-dropdown-test.js
@@ -1,15 +1,135 @@
-import { module, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import Service from '@ember/service';
 
 module(
 	'Integration | Component | community-bar/local-navigation-dropdown',
 	function(hooks) {
 		setupRenderingTest(hooks);
 
-		skip('it renders', async function() {
-			await render(hbs`{{community-bar/local-navigation-dropdown}}`);
+		let clickedNavigationItemLinks = [];
+
+		function createNavigationModel(level = 1) {
+			if (level > 3) {
+				return [];
+			}
+
+			const model = [];
+
+			for (let i = 0; i < 4; i++) {
+				model[i] = {
+					href: `https://example.fandom.com/level/${level}/item/${i}`,
+					title: `Level ${level} Item ${i}`,
+					items: createNavigationModel(level + 1),
+					tracking_label: `${level}-tracking-label-${i}`
+				};
+			}
+
+			return model;
+		}
+
+		hooks.beforeEach(function () {
+			this.owner.register(
+				'service:i18n',
+				Service.extend({
+					t(msg) {
+						return msg;
+					},
+				}),
+			);
+
+			this.set('onLinkClicked', function (event) {
+				event.preventDefault();
+				clickedNavigationItemLinks.push(event.target.href);
+			});
+		});
+
+		test('should render with state', async function (assert) {
+			const model = createNavigationModel();
+
+			this.set('model', model);
+
+			await render(hbs`{{community-bar/local-navigation-dropdown model=model onLinkClicked=(action onLinkClicked)}}`);
+
+			assert.dom('.wds-community-bar__level-1 a').exists({ count: 4 });
+			assert.dom('.wds-community-bar__level-2 li a').exists({ count: 4 * 4 });
+			assert.dom('.wds-community-bar__level-3 li a').exists({ count: 4 * 4 * 4 });
+		});
+
+		async function verifySecondLevelNavigationItemOpened(assert) {
+			await click('.wds-community-bar__level-1 li:nth-child(1) a');
+
+			assert.dom('.wds-community-bar__level-1').hasClass('wds-is-hidden');
+
+			let secondLevelNavigationItems = document.getElementsByClassName('wds-community-bar__level-2');
+
+			for (let i = 0; i < secondLevelNavigationItems.length; i++) {
+				assert.equal(secondLevelNavigationItems[i].classList.contains('wds-is-active'), i === 0);
+			}
+		}
+
+		function verifySubLevelsClosed(assert) {
+			assert.dom('.wds-community-bar__level-1').doesNotHaveClass('wds-is-hidden');
+			assert.dom('.wds-community-bar__level-2').doesNotHaveClass('wds-is-active');
+			assert.dom('.wds-community-bar__level-3').doesNotHaveClass('wds-is-active');
+		}
+
+		test('IW-1341 - should close navigation before navigating to level 1 title', async function (assert) {
+			const model = createNavigationModel();
+
+			this.set('model', model);
+
+			await render(hbs`{{community-bar/local-navigation-dropdown model=model onLinkClicked=(action onLinkClicked)}}`);
+
+			await verifySecondLevelNavigationItemOpened(assert);
+
+			await click('.wds-community-bar__level-2.wds-is-active .wds-community-bar__navigation-header');
+
+			verifySubLevelsClosed(assert);
+		});
+
+		async function verifyFirstThirdLevelNavigationOpened(assert) {
+			await click('.wds-community-bar__level-2.wds-is-active li:first-child a');
+
+			let thirdLevelNavigationItems = document.getElementsByClassName('wds-community-bar__level-3');
+
+			for (let i = 0; i < thirdLevelNavigationItems.length; i++) {
+				assert.equal(thirdLevelNavigationItems[i].classList.contains('wds-is-active'), i === 0);
+			}
+		}
+
+		test('IW-1341 - should close navigation before navigating to level 2 title', async function (assert) {
+			const model = createNavigationModel();
+
+			this.set('model', model);
+
+			await render(hbs`{{community-bar/local-navigation-dropdown model=model onLinkClicked=(action onLinkClicked)}}`);
+
+			await verifySecondLevelNavigationItemOpened(assert);
+
+			await verifyFirstThirdLevelNavigationOpened(assert);
+
+			await click('.wds-community-bar__level-3.wds-is-active .wds-community-bar__navigation-header');
+
+			verifySubLevelsClosed(assert);
+		});
+
+		test('IW-1341 - should close navigation before navigating to level 3 link', async function (assert) {
+			const model = createNavigationModel();
+
+			this.set('model', model);
+
+			await render(hbs`{{community-bar/local-navigation-dropdown model=model onLinkClicked=(action onLinkClicked)}}`);
+
+			await verifySecondLevelNavigationItemOpened(assert);
+
+			await verifyFirstThirdLevelNavigationOpened(assert);
+
+			await click('.wds-community-bar__level-3.wds-is-active li:first-child a');
+
+			verifySubLevelsClosed(assert);
 		});
 	},
 );


### PR DESCRIPTION
If an user clicks a level 2 item title in mobile-wiki community header, the navigation bubble remains visible even though the page has changed. The navigation should always be closed if it triggers a page change.

https://wikia-inc.atlassian.net/browse/IW-1341

@Wikia/iwing 