### PR TITLE
Use custom workspace with no commit hash

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
   agent {
     label {
       label 'qa-executors'
-      customWorkspace "/var/lib/jenkins/workspace/${BRANCH_NAME}"
+      customWorkspace "/var/lib/jenkins/workspace/design-system-pr-${BRANCH_NAME}"
     }
   }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 pipeline {
   agent {
     label 'qa-executors'
+    customWorkspace "/var/lib/jenkins/workspace/${BRANCH_NAME}"
   }
 
   stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,9 @@
 pipeline {
   agent {
-    label 'qa-executors'
-    customWorkspace "/var/lib/jenkins/workspace/${BRANCH_NAME}"
+    label {
+      label 'qa-executors'
+      customWorkspace "/var/lib/jenkins/workspace/${BRANCH_NAME}"
+    }
   }
 
   stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
   agent {
-    label {
+    node {
       label 'qa-executors'
       customWorkspace "/var/lib/jenkins/workspace/design-system-pr-${BRANCH_NAME}"
     }


### PR DESCRIPTION
Fix for: https://wikia-inc.atlassian.net/browse/MAIN-18963
If we specify to override the workspce, it helps with the 
```sh: 1: cannot create /var/lib/jenkins/workspace/ign-system-pr-checks_PR-342-HNS56INYIFWKIAFWJXTK6XPUG37BBYSSNZFCDBOBL2LUAXXJVU6Q@tmp/durable-831424f2/jenkins-result.txt.tmp: Directory nonexistent```
In logs you can see, that once it reserves the workspace the old way, it overrides is before cloning and ot stays overwritten for all steps, and post builds:
```Running on qa-executor68 in /var/lib/jenkins/workspace/ign-system-pr-checks_PR-344-25G6LVGO3PHSU7N5V4UGVYK2TCF27GTHBZXCULEKKXDVLDS2RTTA
[Pipeline] {
[Pipeline] ws
Running in /var/lib/jenkins/workspace/design-system-pr-PR-344
[Pipeline] {
[Pipeline] stage
[Pipeline] { (Declarative: Checkout SCM)
[Pipeline] checkout
Cloning the remote Git repository```