### PR TITLE
IW-1895 | do not preventDefault when action is not passed to icon component

### DIFF
--- a/app/templates/components/icon.hbs
+++ b/app/templates/components/icon.hbs
@@ -1,7 +1,7 @@
 <svg
   class={{classnames "wds-icon" this.sizeClassName (if @chevron "wds-menu-chevron")}}
   ...attributes
-  {{action (optional @onClick)}}
+  {{action (optional @onClick) preventDefault=(if @onClick true false)}}
 >
   <use xlink:href="#{{this.iconName}}"></use>
 </svg>


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/IW-1895

When <Icon> component was used inside <a href="..."> tag and none action was provided, click on the icon did not trigger redirection to the page pointed by <a> tag. This change fixes that

@Wikia/iwing 