### PR TITLE
Fix wds-icons-external-small

### DIFF
--- a/docs/svg/wds-icons-external-small.svg
+++ b/docs/svg/wds-icons-external-small.svg
@@ -1,12 +1,3 @@
 <svg viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <path d="M16.925 1.619a.988.988 0 0 1 .075.378V7a1 1 0 1 1-2 0V4.414l-6.293 6.293a.997.997 0 0 1-1.414 0 1 1 0 0 1 0-1.414L13.586 3H11a1 1 0 1 1 0-2h5.003a.988.988 0 0 1 .704.293.998.998 0 0 1 .218.326zM13 9.999a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h5a1 1 0 1 1 0 2H3v9h9v-4a1 1 0 0 1 1-1z"/>
-  <g fill="none" fill-rule="evenodd">
-    <mask id="mask-2" fill="#fff">
-      <use xlink:href="#path-1-small"/>
-    </mask>
-    <use fill="#999" xlink:href="#path-1-small"/>
-    <g mask="url(#mask-2)" fill="#000">
-      <path d="M0 0h18v18H0z"/>
-    </g>
-  </g>
 </svg>


### PR DESCRIPTION
Remove a mask that causes issues with global footer icons when WDSIcons dev script is imported 